### PR TITLE
Added alias from jasmine-core to jasmine

### DIFF
--- a/data/alias.ts
+++ b/data/alias.ts
@@ -10,4 +10,5 @@ export var all:IAlias[] = [
     {name: "angular", alias: "angular-browserify"},
     {name: "angular", alias: "angularjs"},
     {name: "jquery", alias: "jquery-browserify"},
+    {name: "jasmine-core", alias: "jasmine"},
 ]


### PR DESCRIPTION
DefinitelyTyped contains jasmine definitions under `jasmine`, but the actual jasmine JavaScript code resides in an npm package named `jasmine-core`.
